### PR TITLE
rename storage accounts + readme

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -34,7 +34,17 @@ azure_subscription_id = "your_subscription_id_from_script_execution"
 azure_client_id       = "your_client_id_from_script_execution"
 azure_client_secret   = "your_client_secret_from_script_execution"
 azure_tenant_id       = "your_tenant_id_from_script_execution"
+ssh_public_key        = "usually-your-home-directory/.ssh/id_rsa.pub"
 ```
+
+You might also want to add the following variables, to create a unique deployment:
+```
+resource_group_name   = "INSERT_SOMETHING, but only alphanumeric and hyphens"
+dns_prefix            = "INSERT_SOMETHING"
+cluster_name          = "INSERT_SOMETHING,"
+jenkins_rg_name       = "INSERT_SOMETHIN, but only alphanumeric and underscores "
+```
+
 Run
 `terraform init`
 to download the azure terraform provider

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -60,7 +60,8 @@ terraform apply "run.plan"
 
 This take few minutes to complete...
 
-Let's check that our cluster is up and running (Terraform output variable will contains the raw configuration of the newly created Kubernetes cluster)
+Let's check that our cluster is up and running (Terraform output variable will contains the raw configuration of the newly created Kubernetes cluster).
+You might need to disable the equinor proxy enviornment variables first. 
 
 ```
 echo "$(terraform output kube_config)" > ~/.kube/kubeflow

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -6,6 +6,8 @@ Deployment script for data analytics platform based on Terraform.
 
 Azure command line installed and user authenticated
 
+Terraform installed
+
 # Setup
 
 Create an Azure Service principal RBAC user with Contributor role 
@@ -33,6 +35,10 @@ azure_client_id       = "your_client_id_from_script_execution"
 azure_client_secret   = "your_client_secret_from_script_execution"
 azure_tenant_id       = "your_tenant_id_from_script_execution"
 ```
+Run
+`terraform init`
+to download the azure terraform provider
+
 
 Run 
 `terraform plan -out run.plan`

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -47,7 +47,7 @@ output "host" {
 }
 
 resource "azurerm_container_registry" "acr" {
-  name                = "azcore"
+  name                = "${replace(azurerm_resource_group.dcoe_rg.name, "-", "")}acr"
   resource_group_name = "${azurerm_resource_group.dcoe_rg.name}"
   location            = "${azurerm_resource_group.dcoe_rg.location}"
   sku                 = "standard"
@@ -55,7 +55,7 @@ resource "azurerm_container_registry" "acr" {
 
 # Storage account for AKS cluster
 resource "azurerm_storage_account" "storageac" {
-  name                     = "dcoestorageac"
+  name                     = "${replace(azurerm_resource_group.dcoe_rg.name, "-", "")}dcoesac"
   resource_group_name      = "${azurerm_kubernetes_cluster.k8s.node_resource_group}"
   location                 = "${azurerm_resource_group.dcoe_rg.location}"
   account_tier             = "Standard"
@@ -114,7 +114,7 @@ resource "azurerm_resource_group" "jenkins_rg_name" {
 
 # Storage account for AKS cluster
 resource "azurerm_storage_account" "jenkinsstorageac" {
-  name                     = "jenkinsstorageac"
+  name                     = "${replace(azurerm_resource_group.jenkins_rg_name.name, "_","")}jstoracc"
   resource_group_name      = "${azurerm_resource_group.jenkins_rg_name.name}"
   location                 = "${azurerm_resource_group.jenkins_rg_name.location}"
   account_tier             = "Standard"


### PR DESCRIPTION
Minor README additions, but also changed the names of the following deployed resources in the terraform-script to include appropriate variables in their name, so different deployments wont step on each others feet. 

- jenkinsstorageac
- dcoestorageac
- azcore (container registry)