### PR TITLE
Add kubernetes_version=1.10.8

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -11,6 +11,7 @@ resource "azurerm_kubernetes_cluster" "k8s" {
   location            = "${azurerm_resource_group.dcoe_rg.location}"
   resource_group_name = "${azurerm_resource_group.dcoe_rg.name}"
   dns_prefix          = "${var.dns_prefix}"
+  kubernetes_version  = "${var.kubernetes_version}"
 
   linux_profile {
     admin_username = "ubuntu"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -13,6 +13,10 @@ variable "location" {
 }
 
 # Kubernetes variables
+variable "kubernetes_version" {
+  default = "1.10.8"
+}
+
 variable "agent_count" {
   default = "5"
 }


### PR DESCRIPTION
Add the ability to customize the deployed kubernetes version. Sets default to 1.10.8, which seemed to be the newest supported in azure. 

This closes #2 .